### PR TITLE
update some function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /tags
 __pycache__
 /.vscode
+/.idea

--- a/taichi_glsl/sampling.py
+++ b/taichi_glsl/sampling.py
@@ -132,10 +132,14 @@ def trilerp(field: ti.template(), P):
     w0 = ts.fract(P)
     w1 = 1.0 - w0
 
-    c00 = ts.sample(field, I + ts.D.yyy) * w1.x + ts.sample(field, I + ts.D.xyy) * w0.x
-    c01 = ts.sample(field, I + ts.D.yyx) * w1.x + ts.sample(field, I + ts.D.xyx) * w0.x
-    c10 = ts.sample(field, I + ts.D.yxy) * w1.x + ts.sample(field, I + ts.D.xxy) * w0.x
-    c11 = ts.sample(field, I + ts.D.yxx) * w1.x + ts.sample(field, I + ts.D.xxx) * w0.x
+    c00 = ts.sample(field, I + ts.D.yyy) * w1.x + ts.sample(
+        field, I + ts.D.xyy) * w0.x
+    c01 = ts.sample(field, I + ts.D.yyx) * w1.x + ts.sample(
+        field, I + ts.D.xyx) * w0.x
+    c10 = ts.sample(field, I + ts.D.yxy) * w1.x + ts.sample(
+        field, I + ts.D.xxy) * w0.x
+    c11 = ts.sample(field, I + ts.D.yxx) * w1.x + ts.sample(
+        field, I + ts.D.xxx) * w0.x
 
     c0 = c00 * w1.y + c10 * w0.y
     c1 = c01 * w1.y + c11 * w0.y

--- a/taichi_glsl/sampling.py
+++ b/taichi_glsl/sampling.py
@@ -94,6 +94,56 @@ def bilerp(field: ti.template(), P):
 
 
 @ti.func
+def trilerp(field: ti.template(), P):
+    '''
+    Tilinear sampling an 3D field with a real index.
+
+    :parameter field: (3D Tensor)
+        Specify the field to sample.
+
+    :parameter P: (3D Vector of float)
+        Specify the index in field.
+
+    :note:
+        If one of the element to be accessed is out of `field.shape`, then
+        `Tilerp` will automatically do a clamp for you, see :func:`sample`.
+
+        Syntax ref : https://en.wikipedia.org/wiki/Trilinear_interpolation.
+
+    :return:
+        The return value is calcuated as::
+
+            I = int(P)
+            w0 = ts.fract(P)
+            w1 = 1.0 - w0
+            c00 = ts.sample(field, I + ts.D.yyy) * w1.x + ts.sample(field, I + ts.D.xyy) * w0.x
+            c01 = ts.sample(field, I + ts.D.yyx) * w1.x + ts.sample(field, I + ts.D.xyx) * w0.x
+            c10 = ts.sample(field, I + ts.D.yxy) * w1.x + ts.sample(field, I + ts.D.xxy) * w0.x
+            c11 = ts.sample(field, I + ts.D.yxx) * w1.x + ts.sample(field, I + ts.D.xxx) * w0.x
+
+            c0 = c00 * w1.y + c10 * w0.y
+            c1 = c01 * w1.y + c11 * w0.y
+
+            return c0 * w1.z + c1 * w0.z
+
+        .. where D = vec(1, 0, -1)
+    '''
+    I = int(P)
+    w0 = ts.fract(P)
+    w1 = 1.0 - w0
+
+    c00 = ts.sample(field, I + ts.D.yyy) * w1.x + ts.sample(field, I + ts.D.xyy) * w0.x
+    c01 = ts.sample(field, I + ts.D.yyx) * w1.x + ts.sample(field, I + ts.D.xyx) * w0.x
+    c10 = ts.sample(field, I + ts.D.yxy) * w1.x + ts.sample(field, I + ts.D.xxy) * w0.x
+    c11 = ts.sample(field, I + ts.D.yxx) * w1.x + ts.sample(field, I + ts.D.xxx) * w0.x
+
+    c0 = c00 * w1.y + c10 * w0.y
+    c1 = c01 * w1.y + c11 * w0.y
+
+    return c0 * w1.z + c1 * w0.z
+
+
+@ti.func
 def superSample2x2(fieldFunc: ti.template(), P, dx=1):
     dD = dx / 2 * D
     return (fieldFunc(P + dD.yy) + fieldFunc(P + dD.yz) +

--- a/taichi_glsl/scalar.py
+++ b/taichi_glsl/scalar.py
@@ -61,14 +61,14 @@ def sign(x, edge=0):
 
     :note:
         `sign(x, edge)` is equivalent with `sign(x - edge)`.
-        Currently Taichi use -1 to represent True. Consequently we add isTrue here.
+        Currently Taichi use -1 to represent True. Consequently we add truth here.
 
     :return:
         The return value is computed as `(x >= edge) - (x <= edge)`,
         with type promoted.
     '''
     ret = x + edge  # type promotion
-    ret = Truth(x >= edge) - Truth(x <= edge)
+    ret = truth(x >= edge) - truth(x <= edge)
     return ret
 
 
@@ -241,15 +241,15 @@ def isinf(x):
 
 
 @ti.pyfunc
-def Truth(cond):
+def truth(cond):
     '''
         return 1 if condition is not false, return 0 vice versa
     :param x:
 
     :return:
-        The return value is computed as `return abs(cond != 0)`
+        The return value is computed as `return ti.select(cond, 1, 0)`
         note: Currently Taichi use -1 to represent True.
         This function serves as a helper function to those who want 1 to represent True
 
     '''
-    return abs(cond != 0)
+    return ti.select(cond, 1, 0)

--- a/taichi_glsl/scalar.py
+++ b/taichi_glsl/scalar.py
@@ -61,13 +61,14 @@ def sign(x, edge=0):
 
     :note:
         `sign(x, edge)` is equivalent with `sign(x - edge)`.
+        Currently Taichi use -1 to represent True, so add ti.abs here.
 
     :return:
         The return value is computed as `(x >= edge) - (x <= edge)`,
         with type promoted.
     '''
     ret = x + edge  # type promotion
-    ret = (x >= edge) - (x <= edge)
+    ret = ti.abs(x >= edge) - ti.abs(x <= edge)
     return ret
 
 

--- a/taichi_glsl/scalar.py
+++ b/taichi_glsl/scalar.py
@@ -61,14 +61,14 @@ def sign(x, edge=0):
 
     :note:
         `sign(x, edge)` is equivalent with `sign(x - edge)`.
-        Currently Taichi use -1 to represent True, so add ti.abs here.
+        Currently Taichi use -1 to represent True. Consequently we add isTrue here.
 
     :return:
         The return value is computed as `(x >= edge) - (x <= edge)`,
         with type promoted.
     '''
     ret = x + edge  # type promotion
-    ret = ti.abs(x >= edge) - ti.abs(x <= edge)
+    ret = isTrue(x >= edge) - isTrue(x <= edge)
     return ret
 
 
@@ -238,3 +238,18 @@ def isinf(x):
         The return value is computed as `2 * x == x and x != 0`.
     '''
     return 2 * x == x and x != 0
+
+
+@ti.pyfunc
+def isTrue(cond):
+    '''
+        return 1 if condition is not false, return 0 vice versa
+    :param x:
+
+    :return:
+        The return value is computed as `return abs(cond != 0)`
+        note: Currently Taichi use -1 to represent True.
+        This function serves as a helper function to those who want 1 to represent True
+
+    '''
+    return abs(cond != 0)

--- a/taichi_glsl/scalar.py
+++ b/taichi_glsl/scalar.py
@@ -68,7 +68,7 @@ def sign(x, edge=0):
         with type promoted.
     '''
     ret = x + edge  # type promotion
-    ret = isTrue(x >= edge) - isTrue(x <= edge)
+    ret = Truth(x >= edge) - Truth(x <= edge)
     return ret
 
 
@@ -241,7 +241,7 @@ def isinf(x):
 
 
 @ti.pyfunc
-def isTrue(cond):
+def Truth(cond):
     '''
         return 1 if condition is not false, return 0 vice versa
     :param x:

--- a/taichi_glsl/vector.py
+++ b/taichi_glsl/vector.py
@@ -53,7 +53,8 @@ def vecND(n, *xs):
     Create a n-D vector by scalars or vectors in arguments (GLSL-alike).
 
     The return vector dimension depends on **the specified argument n**.
-    If the dimension mismatch, the function would either clamp or pad with zero
+    If the dimension mismatch the count of scalars in xs, an error
+    will be raised.
     However, if only one scalar is specified, then `vecND(n, x)` is
     equivalent to `vecFill(n, x)`, see :func:`vecFill`.
 
@@ -86,13 +87,13 @@ def vecND(n, *xs):
         else:
             ys.append(x)
 
-    if len(ys) > n:
-        ys = ys[:n]
-    else:
-        ys.extend((n - len(ys)) * [0])
-    # if len(ys) != n:
-    #     raise ValueError(f'Cannot generate {n}-D vector from '
-    #                      f'{len(ys)} scalars')
+    # if len(ys) > n:
+    #     ys = ys[:n]
+    # else:
+    #     ys.extend((n - len(ys)) * [0])
+    if len(ys) != n:
+        raise ValueError(f'Cannot generate {n}-D vector from '
+                         f'{len(ys)} scalars')
 
     return vecSimple(*ys)
 

--- a/taichi_glsl/vector.py
+++ b/taichi_glsl/vector.py
@@ -53,8 +53,7 @@ def vecND(n, *xs):
     Create a n-D vector by scalars or vectors in arguments (GLSL-alike).
 
     The return vector dimension depends on **the specified argument n**.
-    If the dimension mismatch the count of scalars in xs, an error
-    will be raised.
+    If the dimension mismatch, the function would either clamp or pad with zero
     However, if only one scalar is specified, then `vecND(n, x)` is
     equivalent to `vecFill(n, x)`, see :func:`vecFill`.
 
@@ -87,9 +86,13 @@ def vecND(n, *xs):
         else:
             ys.append(x)
 
-    if len(ys) != n:
-        raise ValueError(f'Cannot generate {n}-D vector from '
-                         f'{len(ys)} scalars')
+    if len(ys) > n:
+        ys = ys[:n]
+    else:
+        ys.extend((n - len(ys)) * [0])
+    # if len(ys) != n:
+    #     raise ValueError(f'Cannot generate {n}-D vector from '
+    #                      f'{len(ys)} scalars')
 
     return vecSimple(*ys)
 


### PR DESCRIPTION
1. adapt the `ts.sign` function. Since **Taichi** currently use -1 as True
2. add `ts.bilerp` function
3. support `ts.vec` with clamping, or padding zero

for instance:

```python
a = ts.vec3(2, 3, 3)
b = ts.vec2(a) # (2, 3)
c = ts.vec3(b) # (2, 3, 0)
```

The would make `ts.vec` more like `glm::vec`

**Note**: I haven't fully test the **3rd** feature yet, so maybe somebody could help with this?